### PR TITLE
fix-#1: fixes '.remove() is not a function' in IE

### DIFF
--- a/whimsicalRipple.js
+++ b/whimsicalRipple.js
@@ -78,7 +78,7 @@
             ripple[0].style.left = left + 'px';
             ripple[0].style.top = top + 'px';
             ripple.on('animationend webkitAnimationEnd', function() {
-              this.remove();
+              angular.element(this).remove();
             });
 
             element.append(ripple);


### PR DESCRIPTION
Wrapped 'this' reference for jqLite/jQuery .remove() method
